### PR TITLE
入力文字列からスペースと改行を消す

### DIFF
--- a/MeetupTweet/Classes/Presentation/AuthViewModel.swift
+++ b/MeetupTweet/Classes/Presentation/AuthViewModel.swift
@@ -38,7 +38,11 @@ class AuthViewModel {
             .shareReplay(1)
 
         
-        let apiKeyAndSecret = Observable.combineLatest(consumerKey, consumerSecret) {($0, $1)}
+        let apiKeyAndSecret = Observable
+            .combineLatest(consumerKey, consumerSecret) {
+                ($0.stringByTrimmingCharactersInSet(.whitespaceAndNewlineCharacterSet()),
+                 $1.stringByTrimmingCharactersInSet(.whitespaceAndNewlineCharacterSet()))
+            }
         
         authorized = authrorizeTap.withLatestFrom(apiKeyAndSecret)
             .flatMapLatest { (consumerKey, consumerSecret) -> Observable<Bool>  in


### PR DESCRIPTION
# なぜやるか

issue #1 の解決のため
# どうやるか
- ViewControllerでスペースと改行を消してもいいけどViewModel側で消すようにする
  - 今後双方向bindを使ってViewModel側で変更したものをViewControllerでbindすることを考慮したため
