### PR TITLE
protocolとenumの名前変更

### DIFF
--- a/MeetupTweet/Classes/CommentType.swift
+++ b/MeetupTweet/Classes/CommentType.swift
@@ -7,13 +7,13 @@
 //
 import Foundation
 
-enum CommentType {
+enum Comment {
     case Tweet
     case Announce
 }
 
-protocol Comment {
-    func type() -> CommentType
+protocol CommentType {
+    func type() -> Comment
     
     func identifier() -> String
     func message() -> String

--- a/MeetupTweet/Classes/Domain/Announce.swift
+++ b/MeetupTweet/Classes/Domain/Announce.swift
@@ -8,12 +8,12 @@
 
 import Foundation
 
-struct Announce: Comment {
+struct Announce: CommentType {
     let id: String
     let text: String
     
-    func type() -> CommentType {
-        return CommentType.Announce
+    func type() -> Comment {
+        return .Announce
     }
     
     func identifier() -> String {

--- a/MeetupTweet/Classes/Domain/AnnounceUseCase.swift
+++ b/MeetupTweet/Classes/Domain/AnnounceUseCase.swift
@@ -11,7 +11,7 @@ import RxSwift
 
 class AnnounceUseCase {
     
-    class func intervalTextStream(text: String) -> Observable<Comment> {
+    class func intervalTextStream(text: String) -> Observable<CommentType> {
         
         let interval = 60.0
         let announceText = " \(text) のTweetを取得中です"

--- a/MeetupTweet/Classes/Domain/Tweet.swift
+++ b/MeetupTweet/Classes/Domain/Tweet.swift
@@ -28,9 +28,9 @@ struct Tweet: Decodable {
     }
 }
 
-extension Tweet: Comment {
-    func type() -> CommentType {
-        return CommentType.Tweet
+extension Tweet: CommentType {
+    func type() -> Comment {
+        return .Tweet
     }
     
     func identifier() -> String {

--- a/MeetupTweet/Classes/Domain/TwitterStreamAPIUseCase.swift
+++ b/MeetupTweet/Classes/Domain/TwitterStreamAPIUseCase.swift
@@ -22,13 +22,13 @@ class TwitterStraemAPIUseCase {
         self.streamingRequest?.stop()
     }
     
-    func startStream(query: String) -> PublishSubject<Comment> {
+    func startStream(query: String) -> PublishSubject<CommentType> {
         
         if let streamingRequest = streamingRequest {
             streamingRequest.stop()
         }
         
-        let tweetStream = PublishSubject<Comment>()
+        let tweetStream = PublishSubject<CommentType>()
         
         streamingRequest = AppDelegate.sharedInstance.oauthClient!
             .streaming(streamEndpoint, parameters: ["track": query])

--- a/MeetupTweet/Classes/Presentation/CommentFlowPresenter.swift
+++ b/MeetupTweet/Classes/Presentation/CommentFlowPresenter.swift
@@ -15,12 +15,11 @@ class CommentFlowPresenter {
     var subscription: Disposable?
     private let tweetSearchUseCase = TwitterStraemAPIUseCase()
     private let disposeBag = DisposeBag()
-    private var comments: [String: (comment: Comment, view: CommentView)] = [:]
+    private var comments: [String: (comment: CommentType, view: CommentView)] = [:]
     private var commentViews: [CommentView?] = []
     private var window: NSWindow = NSWindow()
     
     func searchTweet(search: String, screen: NSScreen) {
-        
         refreshComments()
         window = makeTweetWindow(screen)
 
@@ -54,7 +53,7 @@ private extension CommentFlowPresenter {
         commentViews = []
     }
     
-    func addComment(comment: Comment) {
+    func addComment(comment: CommentType) {
         let view = makeCommentView(comment)
         
         window.contentView?.addSubview(view)
@@ -63,14 +62,14 @@ private extension CommentFlowPresenter {
         startAnimationComment(comment, view: view)
     }
     
-    func removeComment(comment: Comment) {
+    func removeComment(comment: CommentType) {
         if let tweet = comments[comment.identifier()] {
             tweet.view.removeFromSuperview()
             comments[comment.identifier()] = nil
         }
     }
     
-    func startAnimationComment(comment: Comment, view: CommentView) {
+    func startAnimationComment(comment: CommentType, view: CommentView) {
         // TextFieldの移動開始
         let windowFrame = self.window.frame
         
@@ -110,7 +109,7 @@ private extension CommentFlowPresenter {
         )
     }
     
-    func makeCommentView(comment: Comment) -> CommentView {
+    func makeCommentView(comment: CommentType) -> CommentView {
         
         let commentView: CommentView
         switch comment.type() {


### PR DESCRIPTION
# なぜやるか

`protocol Comment`と `enum CommentType`の名前が悩ましいから変えたい
https://twitter.com/_ishkawa/status/720580734805614592

enumのほうは文字通りenumerated typeとして使っているのでTypeと付けてしまって、そのせいでprotocolのほうはTypeを付けられなかったので変更したい。
# どうやるか
- protocolは形容詞か~Typeにしたい
  - Commentableにするとコメントできる何かっぽいので避ける
  - そうなるとCommentTypeが良さそう
- enumは何も考えずに素直にCommentを使う
