### PR TITLE
TwitterAPIがコールバックURLをまともにチェックするようになった対策

### DIFF
--- a/MeetupTweet/AppDelegate.swift
+++ b/MeetupTweet/AppDelegate.swift
@@ -16,7 +16,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     var oauthClient: OAuthClient?
     var requestHandle: OAuthSwiftRequestHandle?
-    
+
+    private let callBackHost = "meetup-tweet"
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         
         NSAppleEventManager.shared().setEventHandler(self, andSelector:#selector(AppDelegate.handleGetURLEvent(_:withReplyEvent:)), forEventClass: AEEventClass(kInternetEventClass), andEventID: AEEventID(kAEGetURL))
@@ -31,10 +33,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc func handleGetURLEvent(_ event: NSAppleEventDescriptor!, withReplyEvent: NSAppleEventDescriptor!) {
-        if let urlString = event.paramDescriptor(forKeyword: AEKeyword(keyDirectObject))?.stringValue, let url = URL(string: urlString) {
-            if url.host == "oauth-callback" {
-                OAuth1Swift.handle(url: url)
-            }
+        if let urlString = event.paramDescriptor(forKeyword: AEKeyword(keyDirectObject))?.stringValue,
+            let url = URL(string: urlString),
+            url.scheme == callBackHost {
+
+            OAuth1Swift.handle(url: url)
         }
     }
 
@@ -50,7 +53,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         return Observable.create { [unowned self] observer in
 
-            self.requestHandle = oauthSwift.authorize(withCallbackURL: "meetup-tweet://oauth-callback/twitter", success: { credential, response, parameters in
+            self.requestHandle = oauthSwift.authorize(withCallbackURL: "\(self.callBackHost)://", success: { credential, response, parameters in
             
                 self.oauthClient = OAuthClient(consumerKey: consumerKey, consumerSecret: consumerSecret, accessToken: credential.oauthToken, accessTokenSecret: credential.oauthTokenSecret)
                 

--- a/MeetupTweet/AppDelegate.swift
+++ b/MeetupTweet/AppDelegate.swift
@@ -14,9 +14,8 @@ import RxSwift
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
 
-    var oauthClient: OAuthClient?
-    var requestHandle: OAuthSwiftRequestHandle?
-
+    private(set) var oauthClient: OAuthClient?
+    private var requestHandle: OAuthSwiftRequestHandle?
     private let callBackHost = "meetup-tweet"
 
     func applicationDidFinishLaunching(_ notification: Notification) {

--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@
 
 ## Develop
 
-- Xcode 9.3 + Swift4.1
+- Xcode 9.4 + Swift4.1
 - Carthage
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
 
 ## Requirements
 
-- [Your Twitter Consumer Key and Consumer Secret](https://apps.twitter.com/)
+- [Twitter Developer Account](https://developer.twitter.com/en/apps)
+  - Your Twitter app `Consumer Key` and `Consumer Secret`
+  - Add Callback URLs `meetup-tweet://` in app details
 - macOS High Sierra
 
 ## Develop


### PR DESCRIPTION
## やったこと

- `meetup-tweet://`をこのツールのURLSchemeとする
- OAuthのコールバックURLを`meetup-tweet://`とする

## 注意点

このツールを使うとき、Twitter DevleoperのページでコールバックURLに`meetup-tweet://`を指定しないと使えないことを注意喚起する必要がある
