### PR TITLE
Single的な使い方をするObservable.createなのでonNextのあとにonCompletedしてあげる

### DIFF
--- a/MeetupTweet/AppDelegate.swift
+++ b/MeetupTweet/AppDelegate.swift
@@ -15,7 +15,6 @@ import RxSwift
 class AppDelegate: NSObject, NSApplicationDelegate {
 
     private(set) var oauthClient: OAuthClient?
-    private var requestHandle: OAuthSwiftRequestHandle?
     let callBackHost = "meetup-tweet"
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -52,7 +51,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         return Observable.create { [unowned self] observer in
 
-            self.requestHandle = oauthSwift.authorize(withCallbackURL: "\(self.callBackHost)://", success: { credential, response, parameters in
+            let requestHandle = oauthSwift.authorize(withCallbackURL: "\(self.callBackHost)://", success: { credential, response, parameters in
 
                 UserDefaults.setToken(credential.oauthToken)
                 UserDefaults.setTokenSecret(credential.oauthTokenSecret)
@@ -71,7 +70,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 observer.onError(error)
             })
 
-            return Disposables.create()
+            return Disposables.create(with: requestHandle!.cancel)
         }
     }
 

--- a/MeetupTweet/AppDelegate.swift
+++ b/MeetupTweet/AppDelegate.swift
@@ -65,6 +65,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 )
                 
                 observer.onNext(true)
+                observer.onCompleted()
 
             }, failure: { error in
                 observer.onError(error)


### PR DESCRIPTION
- onCompletedつけ忘れ疑惑
  - 一度きりのSingle的な使い方をしているObservable.createでonCompleted抜けてた
  - 実際にSingle.createにするかどうかというとそうはしない
    - materializeメソッドはObservableにしか使えないため
- OAuthSwiftRequestHandleを保持する必要がない疑惑
  - そもそもプロパティとして使ってない
  - OAuthSwiftRequestHandleの実態はoauthClient自体で破棄されるものでもない
- dispose時にcancelするようにしておく
